### PR TITLE
Add notice about README.md and CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+Contributing
+============
+
+If you want to propose changes to SOFT MANDEL, you should create a new branch
+with your ideas, and open a pull request to allow the rest of the company to
+discuss your proposed changes. Once at least two others approve the changes,
+and no others dissent, it can be merged. If there's company wide disagreement,
+some sort of consensus must be reached, and failing that, the PR will be rejected.
+
+If your change adds a new section to SOFT MANDEL, remember to add it to the TOC.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ All projects should use GIT for version control. Any deviation from this should 
 
 All repositories should have a remote on Github.
 
+All repositories should have a README.md to explain the purpose of the repo. If your repository is open for contributions from non-team members, or there's important factors not covered by SOFT MANDEL, you should also include a CONTRIBUTING.md to explain guidelines for contributing.
+
 #### Naming repositories
 Repositories should have short names that make it easy to locate a repository and to understand what it does. Our legacy JAVA-inspired package naming scheme is deprecated. It is important that all repositories has a description that explains the purpose to make it easier for others to find things e.g for DrFront `Web application for front page production`.
 


### PR DESCRIPTION
To ease understanding and cross team contributions, every repo should have a README.md and CONTRIBUTING.md. I have chosen to not go into specifics of what these should contain, as I believe that is rather self explanatory. An example CONTRIBUTING.md can be seen here: https://github.com/aptoma/news-portal/blob/develop/CONTRIBUTING.md

As you all know, GitHub renders READMEs beneath the directory listing whenever theres a README in a directory. A link to CONTRIBUTING.md is displayed when people create issues or pull requests.
