### PR TITLE
Replace Jenkins with Travis as recommended CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ We recommend using [PHPCPD](https://github.com/sebastianbergmann/phpcpd) for Cop
 Default configuration files for both PHPMD and JSHint is available at [https://github.com/aptoma/aptoma-bootstrap](https://github.com/aptoma/aptoma-bootstrap)
 
 ### Continuous Integration
-All projects that has some sorts of tests (e.g PHPUnit, linting, mess detection) shall be integrated with an continuous integration server. We suggest using jenkins.aptoma.com that runs Jenkins but the project owners are free to choose another option if they see fit.
+All projects that has some sorts of tests (e.g PHPUnit, linting, mess detection) shall be integrated with an continuous integration server. We suggest using [Travis CI](https://magnum.travis-ci.com/), where we have a pro account.
 
 The use of other CI solutions shall be coordinated with AMP.
 


### PR DESCRIPTION
As our old Jenkins server is getting old, and Jenkins itself isn't quite as smooth as silk, a replacement is needed. The DrFront team, AMP, and myself have all tested using a Travis Pro setup instead, and the results are promising. 

Main takeaways:
- SaaS, no need to manage our own installation
- VM based, meaning no dependencies are shared between repos, and testing with multiple PHP versions is trivial
- Fast, at least a lot faster than our old Jenkins setup
- Easier to configure
- Better integrated with other tools
