### PR TITLE
Add section on user-agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ SOFTware MANagement and DEveLopment Standards in Aptoma.
 	- [Technology and tools](#technology-and-tools)
 		- [Backend](#backend)
 		- [Frontend](#frontend)
+		- [System identification](#system-identification)
 	- [Testing](#testing-2)
 	- [Mess Detection](#mess-detection)
 	- [Continuous Integration](#continuous-integration)
@@ -163,6 +164,19 @@ The recommended CSS preprocessor is [SCSS](http://www.sass-lang.com/guide). Also
 Any customer projects accessible by end users need to support whatever browsers the customer wants to support. Customer admin tools (ie. only used by their internal staff) and our internal tools should support latest versions of Chrome and Firefox.
 
 When adding support for additional browsers infers very little overhead, we should support as broadly as possible. The two latest versions of all major browsers is the industry standard. No version of Internet Explorer is formally supported.
+
+#### System identification
+
+All outgoing HTTP requests should identify the caller via a properly formatted `User-Agent` header. This header should at minimum describe the name, version and environment of the service. All Aptoma services should prefix the system name with `aptoma-`. Additionally, services may add arbitrary data as key-value pairs in parentheses. This format is specified by [RFC9110](https://www.rfc-editor.org/rfc/rfc9110#field.user-agent).
+
+Examples:
+
+```
+User-Agent: aptoma-drpublish/1.2.3 (env:production)
+User-Agent: aptoma-squid/3.2.1 (env:development;source:580e0c33b5ec424880a39254)
+```
+
+As a general rule, avoid including information in `User-Agent` which already exists elsewhere in the request, or can be extracted from information in the request. Examples include the user account (which should be extracted from the authentication), or trace information (which, if included, should exist as standardized [trace headers](https://www.w3.org/TR/trace-context/)).
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ When adding support for additional browsers infers very little overhead, we shou
 
 #### System identification
 
-All outgoing HTTP requests should identify the caller via a properly formatted `User-Agent` header. The first identifier in the header should be `aptoma`, followed by service name and version. Additionally, services may add arbitrary data as key-value pairs in parentheses, of which the minimum requirement is to describe the deployment environment. This format is specified by [RFC9110](https://www.rfc-editor.org/rfc/rfc9110#field.user-agent).
+All outgoing HTTP requests should identify the caller via a properly formatted `User-Agent` header. The first identifier in the header should be `aptoma`, followed by service name and optional version. Additionally, services may add arbitrary data as key-value pairs in parentheses, of which the minimum requirement is to describe the deployment environment. This format is specified by [RFC9110](https://www.rfc-editor.org/rfc/rfc9110#field.user-agent).
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -167,13 +167,13 @@ When adding support for additional browsers infers very little overhead, we shou
 
 #### System identification
 
-All outgoing HTTP requests should identify the caller via a properly formatted `User-Agent` header. This header should at minimum describe the name, version and environment of the service. All Aptoma services should prefix the system name with `aptoma-`. Additionally, services may add arbitrary data as key-value pairs in parentheses. This format is specified by [RFC9110](https://www.rfc-editor.org/rfc/rfc9110#field.user-agent).
+All outgoing HTTP requests should identify the caller via a properly formatted `User-Agent` header. The first identifier in the header should be `aptoma`, followed by service name and version. Additionally, services may add arbitrary data as key-value pairs in parentheses, of which the minimum requirement is to describe the deployment environment. This format is specified by [RFC9110](https://www.rfc-editor.org/rfc/rfc9110#field.user-agent).
 
 Examples:
 
 ```
-User-Agent: aptoma-drpublish/1.2.3 (env:production)
-User-Agent: aptoma-squid/3.2.1 (env:development;source:580e0c33b5ec424880a39254)
+User-Agent: aptoma drpublish/1.2.3 (env:production)
+User-Agent: aptoma squid/3.2.1 (env:development;source:580e0c33b5ec424880a39254)
 ```
 
 As a general rule, avoid including information in `User-Agent` which already exists elsewhere in the request, or can be extracted from information in the request. Examples include the user account (which should be extracted from the authentication), or trace information (which, if included, should exist as standardized [trace headers](https://www.w3.org/TR/trace-context/)).

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ When adding support for additional browsers infers very little overhead, we shou
 
 #### System identification
 
-All outgoing HTTP requests should identify the caller via a properly formatted `User-Agent` header. The first identifier in the header should be `aptoma`, followed by service name and optional version. Additionally, services may add arbitrary data as key-value pairs in parentheses, of which the minimum requirement is to describe the deployment environment. This format is specified by [RFC9110](https://www.rfc-editor.org/rfc/rfc9110#field.user-agent).
+All HTTP backends should identify themselves via a properly formatted `User-Agent` header. The first identifier in the header should be `aptoma`, followed by service name and optional version. Additionally, backends may add arbitrary data as key-value pairs in parentheses, of which the minimum requirement is to describe the deployment environment. This format is specified by [RFC9110](https://www.rfc-editor.org/rfc/rfc9110#field.user-agent).
 
 Examples:
 
@@ -176,7 +176,7 @@ User-Agent: aptoma drpublish/1.2.3 (env:production)
 User-Agent: aptoma squid/3.2.1 (env:development;source:580e0c33b5ec424880a39254)
 ```
 
-As a general rule, avoid including information in `User-Agent` which already exists elsewhere in the request, or can be extracted from information in the request. Examples include the user account (which should be extracted from the authentication), or trace information (which, if included, should exist as standardized [trace headers](https://www.w3.org/TR/trace-context/)).
+As a general rule, avoid including information in `User-Agent` which already exists elsewhere in the request, or can be extracted from information in the request. Examples include the user account (which should be extracted from the authentication), or trace information (which, if included, should exist as standardized [trace headers](https://www.w3.org/TR/trace-context/)). Frontends should not overwrite the `User-Agent` set by the browser.
 
 ### Testing
 


### PR DESCRIPTION
Add section on standardized user-agents in outgoing requests, based on initial discussion [here](https://aptoma.zulipchat.com/#narrow/stream/140843-Smooth-Operators/topic/user-agent/near/406265196).

The only prior art we have is https://github.com/aptoma/print-edition-manager-api/pull/16. In that PR I added the trace ID to the user-agent. I'm now thinking that was a mistake. Any tracing system which supports distributed traces should already decorate outgoing requests with standard [Trace Context](https://www.w3.org/TR/trace-context/) headers. Both opentelemetry and newrelic do this by default. I think a better approach would be to encourage systems to log the trace ID if one exists, which is what I currently do in the PA backends. Including this in user-agent is reinventing the wheel.