### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ We have no requirements for frontend JavaScript frameworks. As frontend technolo
 
 ##### Transpiling
 
-Transpilers should only be used when they bring clear benefits. Use [Babel](https://babeljs.io/) to allow adopting useful JavaScript features before they are supported by all targeted browsers. When a build step is already required by your project, you can use TypeScript.
+Transpilers should only be used when they bring clear benefits. When a build step is already required by your project, you can use TypeScript.
 
 Using CSS preprocessors and postprocessers is OK, and even encouraged. Maintainability and quality of processed code is still more important, though. Don’t use the most esoteric features, unless it clearly adds value (“because you can” != value).
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ We have no requirements for frontend JavaScript frameworks. As frontend technolo
 
 ##### Transpiling
 
-Transpilers should only be used when they bring clear benefits. Use [Babel](https://babeljs.io/) to allow adopting useful JavaScript features before they are supported by all targeted browsers. Don't use TypeScript.
+Transpilers should only be used when they bring clear benefits. Use [Babel](https://babeljs.io/) to allow adopting useful JavaScript features before they are supported by all targeted browsers. When a build step is already required by your project, you can use TypeScript.
 
 Using CSS preprocessors and postprocessers is OK, and even encouraged. Maintainability and quality of processed code is still more important, though. Don’t use the most esoteric features, unless it clearly adds value (“because you can” != value).
 


### PR DESCRIPTION
Update to allow TypeScript for projects with a build step.

Experiments with TypeScript in different DrEdition code bases has provided promising results. When the project setup allows writing TypeScript with all relevant tooling working as intended, there's no reason to disallow TypeScript.

Also better reflects current practices in the DrEdition team.