### PR TITLE
Switch to PSR-12

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ When there’s an industry standard coding style for a language, we should adopt
 
 #### PHP
 
-All PHP code should conform to the [PSR-2 standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
+All PHP code should conform to the [PSR-12 standard](https://www.php-fig.org/psr/psr-12/).
 
 #### JavaScript
 


### PR DESCRIPTION
As PSR-2 is deprecated, we should probably use PSR-12 as the baseline.

@aptomalars Can you assess whether this makes sense for DrPublish?